### PR TITLE
add support for the S3 based boards, which need different settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 .vscode/settings.json
+*.bak

--- a/boards/T5-ePaper-S3.json
+++ b/boards/T5-ePaper-S3.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_MODE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0X303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LilyGo T5-ePaper-S3",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.lilygo.cc/products/t5-4-7-inch-e-paper-v2-3",
+  "vendor": "LILYGO"
+}

--- a/boards/T5-ePaper.json
+++ b/boards/T5-ePaper.json
@@ -1,0 +1,33 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": "-DBOARD_HAS_PSRAM",
+    "f_cpu": "240000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "esp32"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "LILYGO T5-ePaper-ESP32",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 4521984,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.lilygo.cc/products/t5-4-7-inch-e-paper-v2-3",
+  "vendor": "LILYGO"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,10 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+boards_dir = boards
+default_envs = esp32dev
+
 ;[env:esp32doit-devkit-v1]
 ;platform = espressif32
 ;board = esp32dev
@@ -20,9 +24,11 @@
 
 [common_env_data]
 framework = arduino
-board_build.f_cpu = 80000000L
+platform = espressif32@6.8.1
 upload_speed = 921600
+upload_port = COM4
 monitor_speed = 115200
+monitor_port = COM4
 lib_deps =
     Wire@2.0.0
     https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
@@ -32,10 +38,32 @@ build_flags =
     -DBOARD_HAS_PSRAM
 
 [env:esp32dev]
-platform = espressif32@6.8.1
+extends = common_env_data
 board = esp32dev
-framework = ${common_env_data.framework}
-upload_speed = ${common_env_data.upload_speed}
-monitor_speed = ${common_env_data.monitor_speed}
+board_build.f_cpu = 80000000L 
+;framework = ${common_env_data.framework}
+;upload_speed = ${common_env_data.upload_speed}
+;monitor_speed = ${common_env_data.monitor_speed}
+;lib_deps = ${common_env_data.lib_deps}
+;build_flags = ${common_env_data.build_flags}
+
+; define the new ESP32S3 variant, the board file has all the necessary settings
+[esp32s3_base]
+extends = common_env_data
+board = T5-ePaper-S3
+;board_build.boot_freq = 80m
+build_flags =
+    -D BOARD_HAS_PSRAM
+    -D CORE_DEBUG_LEVEL=3
+    -D CONFIG_IDF_TARGET_ESP32S3=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+
+[env:t5-47-plus]
+extends = esp32s3_base
+upload_protocol = esptool
+debug_tool = esp-builtin
+build_type = debug
+;debug_build_flags = -O0 -g 
+debug_init_break = tbreak setup
 lib_deps = ${common_env_data.lib_deps}
-build_flags = ${common_env_data.build_flags}
+           https://github.com/lewisxhe/PCF8563_Library.git


### PR DESCRIPTION
Added 2 board files, which to my knowledge best represent the old ESP32 based boards as well as the new ESP32S3 based variant. This also requires some adaprions to the platformio.ini 